### PR TITLE
Beat Saber: add Danger's "hash" to the Base Game Extras pack

### DIFF
--- a/connections/beatsaber_packs.json
+++ b/connections/beatsaber_packs.json
@@ -1,6 +1,6 @@
 {
 	"OST Vol. 1": ["100bills", "balearicpumping", "beatsaber", "breezer", "commercialpumping", "countryrounds", "escape", "legend", "lvlinsane", "turnmeon"],
-	"Base Game Extras": ["angelvoices", "onehope", "popstars", "crabrave", "fitbeat", "spookybeat", "100billsremix", "escaperemix"],
+	"Base Game Extras": ["angelvoices", "onehope", "popstars", "crabrave", "fitbeat", "spookybeat", "100billsremix", "escaperemix", "danger"],
 	"OST Vol. 2": ["bethereforyou", "elixia", "ineedyou", "rumnbass", "unlimitedpower"],
 	"Monstercat DLC Pack": ["boundless", "emojivip", "epic", "feelingstronger", "overkill", "rattlesnake", "stronger", "thistime", "tillitsover", "wewontbealone"],
 	"Imagine Dragons DLC Pack": ["badliar", "believer", "digital", "itstime", "machine", "natural", "radioactive", "thunder", "warriors", "whateverittakes", "bones", "enemy"],


### PR DESCRIPTION
"from Base Game Extras" will now show when someone plays Danger.

<img width="1312" height="911" alt="A screenshot of a replay of the song Danger by Teminite and Boom Kitty on Beat Saber, as well as the overlay showing the base game pack the song is in." src="https://github.com/user-attachments/assets/8c9b9478-16b3-4188-ba2d-eb6b29e78d56" />
